### PR TITLE
Add MarkdownSection component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "document-copilot",
       "version": "0.1.0",
       "dependencies": {
+        "marked": "^15.0.12",
         "next": "15.3.3",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
@@ -4521,6 +4522,18 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0"
+      }
+    },
+    "node_modules/marked": {
+      "version": "15.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
+      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/math-intrinsics": {

--- a/package.json
+++ b/package.json
@@ -9,19 +9,20 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "marked": "^15.0.12",
+    "next": "15.3.3",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "next": "15.3.3"
+    "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "typescript": "^5",
+    "@eslint/eslintrc": "^3",
+    "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "@tailwindcss/postcss": "^4",
-    "tailwindcss": "^4",
     "eslint": "^9",
     "eslint-config-next": "15.3.3",
-    "@eslint/eslintrc": "^3"
+    "tailwindcss": "^4",
+    "typescript": "^5"
   }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,22 +1,11 @@
+'use client';
+
+import MarkdownSection from '@/components/MarkdownSection';
+
 export default function Home() {
   return (
     <div className="relative min-h-screen p-4">
-      <div
-        contentEditable
-        suppressContentEditableWarning
-        className="border p-4 min-h-[200px]"
-      >
-        Editable content
-      </div>
-      <div className="fixed bottom-2 left-1/2 -translate-x-1/2 flex w-[80%] items-center">
-        <input
-          type="text"
-          className="flex-grow bg-transparent border rounded p-2"
-        />
-        <button className="ml-2 bg-blue-600 text-white rounded px-4 py-2">
-          Send
-        </button>
-      </div>
+      <MarkdownSection content="Editable content" />
     </div>
   );
 }

--- a/src/components/MarkdownSection.tsx
+++ b/src/components/MarkdownSection.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useState, useRef } from "react";
+import { marked } from "marked";
+
+interface MarkdownSectionProps {
+  content: string;
+}
+
+export default function MarkdownSection({ content }: MarkdownSectionProps) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [text, setText] = useState(content);
+  const divRef = useRef<HTMLDivElement>(null);
+
+  const handleDoubleClick = () => {
+    setIsEditing(true);
+    // focus the div after state update
+    setTimeout(() => {
+      divRef.current?.focus();
+    });
+  };
+
+  const handleBlur = () => {
+    if (divRef.current) {
+      setText(divRef.current.innerText);
+    }
+    setIsEditing(false);
+  };
+
+  return (
+    <div className="relative">
+      <div
+        ref={divRef}
+        contentEditable={isEditing}
+        suppressContentEditableWarning
+        onDoubleClick={handleDoubleClick}
+        onBlur={handleBlur}
+        className="border p-4 min-h-[200px] outline-none"
+        dangerouslySetInnerHTML={!isEditing ? { __html: marked.parse(text) } : undefined}
+      >
+        {isEditing ? text : undefined}
+      </div>
+      {isEditing && (
+        <div className="absolute bottom-2 left-1/2 -translate-x-1/2 flex w-[80%] items-center">
+          <input type="text" className="flex-grow bg-transparent border rounded p-2" />
+          <button className="ml-2 bg-blue-600 text-white rounded px-4 py-2">Send</button>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `marked` dependency for rendering Markdown
- implement `MarkdownSection` React component
- use `MarkdownSection` on the homepage

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684d69ff8d5883338b8db7c368a71f94