### PR TITLE
Add Article component

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,28 @@
 'use client';
 
-import MarkdownSection from '@/components/MarkdownSection';
+import Article from '@/components/Article';
+
+const sample = `# Sample Article
+
+This is a paragraph.
+
+- item 1
+- item 2
+
+> quote line 1
+> quote line 2
+
+---
+
+\`\`\`
+code block
+\`\`\`
+`;
 
 export default function Home() {
   return (
     <div className="relative min-h-screen p-4">
-      <MarkdownSection content="Editable content" />
+      <Article content={sample} />
     </div>
   );
 }

--- a/src/components/Article.tsx
+++ b/src/components/Article.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import MarkdownSection from "./MarkdownSection";
+
+interface ArticleProps {
+  content: string;
+}
+
+function splitSections(content: string): string[] {
+  const sections: string[] = [];
+  const lines = content.split(/\r?\n/);
+  let i = 0;
+
+  const listRegex = /^\s*(?:[-+*]|\d+\.)\s+/;
+  const hrRegex = /^\s*(?:-{3,}|\*{3,}|_{3,})\s*$/;
+  const quoteRegex = /^>/;
+
+  while (i < lines.length) {
+    const line = lines[i];
+
+    // code block
+    if (/^```/.test(line)) {
+      const block: string[] = [line];
+      i++;
+      while (i < lines.length && !/^```/.test(lines[i])) {
+        block.push(lines[i]);
+        i++;
+      }
+      if (i < lines.length) {
+        block.push(lines[i]);
+        i++;
+      }
+      sections.push(block.join("\n"));
+      continue;
+    }
+
+    // block quote
+    if (quoteRegex.test(line)) {
+      const block: string[] = [line];
+      i++;
+      while (i < lines.length && quoteRegex.test(lines[i])) {
+        block.push(lines[i]);
+        i++;
+      }
+      sections.push(block.join("\n"));
+      continue;
+    }
+
+    // list
+    if (listRegex.test(line)) {
+      const block: string[] = [line];
+      i++;
+      while (i < lines.length && listRegex.test(lines[i])) {
+        block.push(lines[i]);
+        i++;
+      }
+      sections.push(block.join("\n"));
+      continue;
+    }
+
+    // horizontal rule
+    if (hrRegex.test(line)) {
+      sections.push(line);
+      i++;
+      continue;
+    }
+
+    sections.push(line);
+    i++;
+  }
+
+  return sections;
+}
+
+export default function Article({ content }: ArticleProps) {
+  const sections = splitSections(content);
+  return (
+    <div className="flex flex-col gap-4">
+      {sections.map((section, idx) => (
+        <MarkdownSection key={idx} content={section} />
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- parse markdown content into sections and display them with `MarkdownSection`
- demonstrate `Article` component usage on the home page

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684d77e357048333a158bd4835175635