### PR TITLE
Update styling for light theme

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -12,12 +12,6 @@
   --font-mono: var(--font-geist-mono);
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
-}
 
 body {
   background: var(--background);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -26,12 +26,14 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
-        <header className="flex justify-end p-4">
-          <Link href="/config" className="underline">
-            Config
-          </Link>
-        </header>
-        {children}
+        <div className="mx-auto w-[80vw] max-w-[1200px]">
+          <header className="flex justify-end p-4">
+            <Link href="/config" className="underline">
+              Config
+            </Link>
+          </header>
+          {children}
+        </div>
       </body>
     </html>
   );

--- a/src/components/MarkdownSection.tsx
+++ b/src/components/MarkdownSection.tsx
@@ -35,7 +35,7 @@ export default function MarkdownSection({ content }: MarkdownSectionProps) {
         suppressContentEditableWarning
         onDoubleClick={handleDoubleClick}
         onBlur={handleBlur}
-        className="border p-4 min-h-[200px] outline-none"
+        className="border border-gray-300 rounded p-4 min-h-[200px] outline-none"
         dangerouslySetInnerHTML={!isEditing ? { __html: marked.parse(text) } : undefined}
       >
         {isEditing ? text : undefined}


### PR DESCRIPTION
## Summary
- remove dark scheme styles
- set layout container width to `80vw` with 1200px max
- soften Markdown section border and round corners

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684d79f3861883338443ab3b4f5a7bae