### PR TITLE
Style tweaks to article and inputs

### DIFF
--- a/src/app/config/page.tsx
+++ b/src/app/config/page.tsx
@@ -31,7 +31,7 @@ export default function ConfigPage() {
           <select
             value={provider}
             onChange={(e) => setProvider(e.target.value)}
-            className="border p-2 rounded"
+            className="border p-2 rounded-lg"
           >
             <option value="chatgpt">Use ChatGPT.com</option>
             <option value="openai">Use OpenAI API</option>
@@ -45,7 +45,7 @@ export default function ConfigPage() {
                 type="text"
                 value={apiKey}
                 onChange={(e) => setApiKey(e.target.value)}
-                className="border p-2 rounded"
+                className="border p-2 rounded-lg"
               />
             </label>
             <label className="flex flex-col gap-1">
@@ -54,7 +54,7 @@ export default function ConfigPage() {
                 type="text"
                 value={model}
                 onChange={(e) => setModel(e.target.value)}
-                className="border p-2 rounded"
+                className="border p-2 rounded-lg"
               />
             </label>
             <label className="flex flex-col gap-1">
@@ -63,12 +63,12 @@ export default function ConfigPage() {
                 type="text"
                 value={baseUrl}
                 onChange={(e) => setBaseUrl(e.target.value)}
-                className="border p-2 rounded"
+                className="border p-2 rounded-lg"
               />
             </label>
           </>
         )}
-        <button onClick={save} className="bg-blue-600 text-white rounded py-2">
+        <button onClick={save} className="bg-blue-600 text-white rounded-lg py-2">
           Save
         </button>
       </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -21,8 +21,10 @@ code block
 
 export default function Home() {
   return (
-    <div className="relative min-h-screen p-4">
-      <Article content={sample} />
+    <div className="relative min-h-screen p-4 flex justify-center">
+      <div className="w-full max-w-2xl">
+        <Article content={sample} />
+      </div>
     </div>
   );
 }

--- a/src/components/MarkdownSection.tsx
+++ b/src/components/MarkdownSection.tsx
@@ -53,15 +53,15 @@ export default function MarkdownSection({ content }: MarkdownSectionProps) {
         onDoubleClick={handleDoubleClick}
         onBlur={handleBlur}
         onInput={handleInput}
-        className="markdown border border-gray-300 rounded p-4 min-h-[200px] outline-none"
+        className="markdown border border-gray-300 rounded-lg p-4 min-h-[200px] outline-none"
         dangerouslySetInnerHTML={!isEditing ? { __html: marked.parse(text) } : undefined}
       >
         {isEditing ? text : undefined}
       </div>
       {isEditing && (
         <div className="absolute bottom-2 left-1/2 -translate-x-1/2 flex w-[80%] items-center">
-          <input type="text" className="flex-grow bg-transparent border rounded p-2" />
-          <button className="ml-2 bg-blue-600 text-white rounded px-4 py-2">Send</button>
+          <input type="text" className="flex-grow bg-transparent border rounded-lg p-2" />
+          <button className="ml-2 bg-blue-600 text-white rounded-lg px-4 py-2">Send</button>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- shrink article width to match Codex style
- round Markdown container and input fields more generously
- round config page inputs and button

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684d8c2e9ecc83338952bc3866aba7f1