### PR TITLE
Update MarkdownSection to use textarea editing

### DIFF
--- a/src/components/MarkdownSection.tsx
+++ b/src/components/MarkdownSection.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef } from "react";
+import { useState, useRef, useEffect } from "react";
 import { marked } from "marked";
 
 interface MarkdownSectionProps {
@@ -10,54 +10,42 @@ interface MarkdownSectionProps {
 export default function MarkdownSection({ content }: MarkdownSectionProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [text, setText] = useState(content);
-  const divRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   const handleDoubleClick = () => {
     setIsEditing(true);
-    if (textareaRef.current) {
-      textareaRef.current.value = text;
-    }
-    // focus the div after state update
-    setTimeout(() => {
-      divRef.current?.focus();
-    });
   };
 
   const handleBlur = () => {
-    if (textareaRef.current) {
-      const newText = textareaRef.current.value;
-      setText(newText);
-      textareaRef.current.value = newText;
-    }
     setIsEditing(false);
   };
 
-  const handleInput = () => {
-    if (divRef.current && textareaRef.current) {
-      textareaRef.current.value = divRef.current.innerText;
+  useEffect(() => {
+    if (isEditing) {
+      textareaRef.current?.focus();
     }
-  };
+  }, [isEditing]);
+
+  const commonClasses =
+    "border border-gray-300 rounded-lg p-4 min-h-[200px] outline-none w-full";
 
   return (
     <div className="relative">
-      <textarea
-        ref={textareaRef}
-        defaultValue={text}
-        className="hidden"
-      />
-      <div
-        ref={divRef}
-        contentEditable={isEditing}
-        suppressContentEditableWarning
-        onDoubleClick={handleDoubleClick}
-        onBlur={handleBlur}
-        onInput={handleInput}
-        className="markdown border border-gray-300 rounded-lg p-4 min-h-[200px] outline-none"
-        dangerouslySetInnerHTML={!isEditing ? { __html: marked.parse(text) } : undefined}
-      >
-        {isEditing ? text : undefined}
-      </div>
+      {isEditing ? (
+        <textarea
+          ref={textareaRef}
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          onBlur={handleBlur}
+          className={commonClasses}
+        />
+      ) : (
+        <div
+          onDoubleClick={handleDoubleClick}
+          className={`markdown ${commonClasses}`}
+          dangerouslySetInnerHTML={{ __html: marked.parse(text) }}
+        />
+      )}
       {isEditing && (
         <div className="absolute bottom-2 left-1/2 -translate-x-1/2 flex w-[80%] items-center">
           <input type="text" className="flex-grow bg-transparent border rounded-lg p-2" />


### PR DESCRIPTION
## Summary
- refactor MarkdownSection: editing now uses textarea rather than editable div
- autofocus on textarea when entering edit mode
- share styling between display div and textarea

## Testing
- `npx tsc --noEmit`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684d9422161c8333aa90cfd84861693e