### PR TITLE
Refactor splitSections using marked lexer

### DIFF
--- a/src/lib/splitSections.test.ts
+++ b/src/lib/splitSections.test.ts
@@ -35,4 +35,20 @@ code block
       ''
     ]);
   });
+
+  it('handles nested lists and multiple code blocks', () => {
+    const sample = `- item 1\n  - subitem 1\n  - subitem 2\n\n\`\`\`js\ncode1\n\`\`\`\n\nSome text.\n\n\`\`\`python\ncode2\n\`\`\`\n`;
+
+    const result = splitSections(sample);
+    expect(result).toEqual([
+      '- item 1\n  - subitem 1\n  - subitem 2',
+      '',
+      '```js\ncode1\n```',
+      '',
+      'Some text.',
+      '',
+      '```python\ncode2\n```',
+      ''
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary
- replace manual Markdown parsing in `splitSections` with `marked`'s lexer
- add unit test for nested lists and multiple code blocks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e1adc78c8833390bf86882df51451