### PR TITLE
Improve MarkdownSection styling

### DIFF
--- a/src/components/MarkdownSection.tsx
+++ b/src/components/MarkdownSection.tsx
@@ -28,7 +28,7 @@ export default function MarkdownSection({ content }: MarkdownSectionProps) {
   }, [isEditing]);
 
   const commonClasses =
-    "border border-gray-300 rounded-lg p-4 min-h-[200px] outline-none w-full";
+    "border border-gray-200 rounded-lg p-4 min-h-[200px] outline-none w-full";
 
   return (
     <div className="relative">
@@ -48,9 +48,18 @@ export default function MarkdownSection({ content }: MarkdownSectionProps) {
         />
       )}
       {isEditing && (
-        <div className="absolute bottom-2 left-1/2 -translate-x-1/2 flex w-[80%] items-center">
-          <input type="text" className="flex-grow bg-transparent border rounded-lg p-2" />
-          <button className="ml-2 bg-blue-600 text-white rounded-lg px-4 py-2">Send</button>
+        <div className="absolute bottom-2 left-0 right-0 px-4">
+          <div className="relative w-full">
+            <input
+              type="text"
+              className="w-full bg-transparent border border-gray-200 rounded-lg p-2 pr-20"
+            />
+            <button
+              className="absolute right-2 top-1/2 -translate-y-1/2 bg-blue-600 text-white rounded-lg px-4 py-1.5"
+            >
+              Send
+            </button>
+          </div>
         </div>
       )}
     </div>

--- a/src/lib/markdownSanitize.test.ts
+++ b/src/lib/markdownSanitize.test.ts
@@ -5,6 +5,7 @@ import createDOMPurify from 'dompurify';
 describe('DOMPurify sanitization', () => {
   const window = new JSDOM('').window;
   // Assign global window before creating DOMPurify
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (global as any).window = window;
   const DOMPurify = createDOMPurify(window);
 


### PR DESCRIPTION
## Summary
- use lighter gray borders
- align chat input to the section width and place the send button inside
- fix lint error in tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684e219e02b08333a7429eecbc5fa3a0