### PR TITLE
Add input UI and tweak MarkdownSection

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -23,6 +23,15 @@ export default function Home() {
   return (
     <div className="relative min-h-screen p-4 flex justify-center">
       <div className="w-full max-w-2xl">
+        <div className="mb-4 flex w-full gap-2">
+          <input
+            type="text"
+            className="flex-grow bg-transparent border rounded-lg p-2"
+          />
+          <button className="bg-blue-600 text-white rounded-lg px-4 py-2">
+            Send
+          </button>
+        </div>
         <Article content={sample} />
       </div>
     </div>

--- a/src/components/MarkdownSection.tsx
+++ b/src/components/MarkdownSection.tsx
@@ -27,8 +27,8 @@ export default function MarkdownSection({ content }: MarkdownSectionProps) {
     }
   }, [isEditing]);
 
-  const commonClasses =
-    "border border-gray-200 rounded-lg p-4 min-h-[200px] outline-none w-full";
+  const baseClasses = "rounded-lg p-4 min-h-[200px] outline-none w-full";
+  const editingClasses = `border border-gray-200 ${baseClasses}`;
 
   return (
     <div className="relative">
@@ -38,12 +38,12 @@ export default function MarkdownSection({ content }: MarkdownSectionProps) {
           value={text}
           onChange={(e) => setText(e.target.value)}
           onBlur={handleBlur}
-          className={commonClasses}
+          className={editingClasses}
         />
       ) : (
         <div
           onDoubleClick={handleDoubleClick}
-          className={`markdown ${commonClasses}`}
+          className={`markdown ${baseClasses}`}
           dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(marked.parse(text)) }}
         />
       )}


### PR DESCRIPTION
## Summary
- remove default border on MarkdownSection view mode
- add input box and send button at top of home page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e236a958c8333bfbe0ca4df18a829